### PR TITLE
Add Casascius minikey brute-force mode

### DIFF
--- a/WifSolverCuda/Worker.cuh
+++ b/WifSolverCuda/Worker.cuh
@@ -8,6 +8,12 @@
 #include "lib/Math.cuh"
 
 
+struct MiniResult {
+    uint64_t index;
+    uint8_t priv[32];
+};
+
+
 __global__ void kernelUncompressed(bool* buffResult, bool* buffCollectorWork, uint64_t* const __restrict__ buffRangeStart, const int threadNumberOfChecks);
 __global__ void kernelCompressed(bool* buffResult, bool* buffCollectorWork, uint64_t* const __restrict__ buffRangeStart, const int threadNumberOfChecks);
 __global__ void kernelUncompressed(bool* buffResult, bool* buffCollectorWork, uint64_t* const __restrict__ buffRangeStart, const int threadNumberOfChecks, const uint32_t checksum);
@@ -18,6 +24,8 @@ __global__ void kernelCompressed(const int gpuIx, uint32_t* unifiedResult, bool*
 __global__ void kernelCompressed(const int gpuIx, uint32_t* unifiedResult, bool* isResultFlag, uint64_t* const __restrict__ buffRangeStart, const int threadNumberOfChecks, const uint32_t checksum);
 __global__ void kernelUncompressed(const int gpuIx, uint32_t* unifiedResult, bool* isResultFlag, uint64_t* const __restrict__ buffRangeStart, const int threadNumberOfChecks);
 __global__ void kernelUncompressed(const int gpuIx, uint32_t* unifiedResult, bool* isResultFlag, uint64_t* const __restrict__ buffRangeStart, const int threadNumberOfChecks, const uint32_t checksum);
+
+__global__ void kernelMinikey(const uint8_t* startDigits, MiniResult* results, uint32_t* resultCount, bool* isResultFlag, uint64_t total, const int threadNumberOfChecks);
 
 __device__ bool _checksumDoubleSha256CheckUncompressed(unsigned int checksum, beu32* d_hash, uint64_t* _start);
 __device__ bool _checksumDoubleSha256CheckCompressed(unsigned int checksum, beu32* d_hash, uint64_t* _start);

--- a/WifSolverCuda/Worker1.cu
+++ b/WifSolverCuda/Worker1.cu
@@ -3,6 +3,7 @@
 __device__ __constant__ uint64_t _stride[5];
 __device__ __shared__ uint32_t _blockResults[4096];
 __device__ __shared__ bool _blockResultFlag[1];
+__device__ __constant__ char _base58Alphabet[58] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
 __global__ void kernelUncompressed(bool* buffResult, bool* buffCollectorWork, uint64_t* const __restrict__ buffRangeStart, const int threadNumberOfChecks, const uint32_t checksum) {
     uint64_t _start[5];
@@ -189,6 +190,58 @@ __global__ void kernelCompressed(const int gpuIx, uint32_t* unifiedResult, bool*
         _add(_start, _stride);
     }
     summaryShared(gpuIx, unifiedResult, isResultFlag);
+}
+
+__device__ __forceinline__ void _miniAdd(uint8_t* digits, uint64_t add) {
+    for (int i = 21; i >= 0 && add; --i) {
+        uint64_t sum = digits[i] + (add % 58);
+        digits[i] = sum % 58;
+        add = add / 58 + sum / 58;
+    }
+}
+
+__device__ __forceinline__ void _miniIncrement(uint8_t* digits) {
+    for (int i = 21; i >= 0; --i) {
+        if (++digits[i] < 58) {
+            return;
+        }
+        digits[i] = 0;
+    }
+}
+
+__global__ void kernelMinikey(const uint8_t* startDigits, MiniResult* results, uint32_t* resultCount, bool* isResultFlag, uint64_t total, const int threadNumberOfChecks) {
+    uint64_t tIx = (threadIdx.x + blockIdx.x * blockDim.x) * (uint64_t)threadNumberOfChecks;
+    if (tIx >= total) {
+        return;
+    }
+    uint8_t digits[22];
+    for (int i = 0; i < 22; ++i) {
+        digits[i] = startDigits[i];
+    }
+    _miniAdd(digits, tIx);
+    for (uint32_t i = 0; i < threadNumberOfChecks && (tIx + i) < total; ++i) {
+        char key[22];
+        for (int j = 0; j < 22; ++j) {
+            key[j] = _base58Alphabet[digits[j]];
+        }
+        uint8_t temp[23];
+        for (int j = 0; j < 22; ++j) {
+            temp[j] = (uint8_t)key[j];
+        }
+        temp[22] = '?';
+        uint8_t digest[32];
+        sha256(temp, 23, digest);
+        if (digest[0] == 0x00) {
+            sha256((uint8_t*)key, 22, digest);
+            uint32_t slot = atomicAdd(resultCount, 1u);
+            results[slot].index = tIx + i;
+            for (int b = 0; b < 32; ++b) {
+                results[slot].priv[b] = digest[b];
+            }
+            *isResultFlag = true;
+        }
+        _miniIncrement(digits);
+    }
 }
 
 __device__ __inline__ void initShared() {

--- a/WifSolverCuda/lib/hash/sha256.h
+++ b/WifSolverCuda/lib/hash/sha256.h
@@ -18,6 +18,7 @@
 #ifndef SHA256_H
 #define SHA256_H
 #include <string>
+#include <stdint.h>
 
 void sha256(uint8_t* input, size_t length, uint8_t* digest);
 void sha256_33(uint8_t* input, uint8_t* digest);

--- a/WifSolverCuda/main.cu
+++ b/WifSolverCuda/main.cu
@@ -11,6 +11,8 @@
 #include <chrono>
 #include <thread>
 #include <set>
+#include <algorithm>
+#include <string.h>
 
 #include "lib/ctpl/ctpl_stl.h"
 #include "lib/Int.h"
@@ -20,11 +22,19 @@
 #include "Worker.cuh"
 
 #include "lib/SECP256k1.h"
+#include "lib/hash/sha256.h"
 
 using namespace std;
 
 void processCandidate(Int& toTest);
 void processCandidateThread(int id, uint64_t bit0, uint64_t bit1, uint64_t bit2, uint64_t bit3, uint64_t bit4);
+void processMinikeyCandidate(Int& priv, const std::string& mini);
+void bruteForceMinikey(const std::string& start, const std::string& end);
+bool incrementBase58(std::string& s);
+void toDigits(const std::string& s, uint8_t digits[22]);
+uint64_t distanceBase58(const uint8_t* start, const uint8_t* end);
+void addBase58Host(uint8_t* digits, uint64_t add);
+std::string offsetToMini(const uint8_t* startDigits, uint64_t offset);
 bool readArgs(int argc, char** argv);
 bool readFileAddress(const std::string& file_name);
 void showHelp();
@@ -92,6 +102,10 @@ bool IS_VERBOSE = false;
 
 Secp256K1* secp;
 
+bool MINIKEY_MODE = false;
+std::string MINIKEY_START;
+std::string MINIKEY_END;
+
 ctpl::thread_pool pool(2);
 
 int main(int argc, char** argv)
@@ -114,9 +128,16 @@ int main(int argc, char** argv)
         printFooter();
         return 0;
     }
+    if (MINIKEY_MODE) {
+        secp = new Secp256K1();
+        secp->Init();
+        bruteForceMinikey(MINIKEY_START, MINIKEY_END);
+        printFooter();
+        return 0;
+    }
     if (isRestore) {
         restoreSettings(fileStatusRestore);
-    }   
+    }
 
     dataLen = COMPRESSED ? 38 : 37;
     if (!isRANGE_START_TOTAL) {
@@ -802,6 +823,141 @@ void processCandidateThread(int id, uint64_t bit0, uint64_t bit1, uint64_t bit2,
     delete toTest;
 }
 
+void processMinikeyCandidate(Int& priv, const std::string& mini) {
+    FILE* keys;
+    char rmdhash[21], address[128];
+    Point publickey = secp->ComputePublicKey(&priv);
+    if (bech32) {
+        char output[128];
+        uint8_t h160[20];
+        secp->GetHash160(BECH32, true, publickey, h160);
+        segwit_addr_encode(output, "bc", 0, h160, 20);
+        string addressBech32 = std::string(output);
+        strcpy(address, addressBech32.c_str());
+    }
+    else {
+        if (p2sh) {
+            secp->GetHash160(P2SH, true, publickey, (unsigned char*)rmdhash);
+        }
+        else {
+            secp->GetHash160(P2PKH, COMPRESSED, publickey, (unsigned char*)rmdhash);
+        }
+        addressToBase58(rmdhash, address, p2sh);
+    }
+    if (IS_TARGET_ADDRESS) {
+        if (addresses.find(address) != addresses.end()) {
+            RESULT = true;
+            printf("\n");
+            printf("found: %s\n", address);
+            printf("key  : %s\n", priv.GetBase16().c_str());
+            printf("mini : %s\n", mini.c_str());
+            keys = fopen(fileResult.c_str(), "a+");
+            fprintf(keys, "%s\n", address);
+            fprintf(keys, "%s\n", mini.c_str());
+            fprintf(keys, "%s\n\n", priv.GetBase16().c_str());
+            fclose(keys);
+        }
+    }
+    else {
+        printf("\n");
+        printf("found: %s\n", address);
+        printf("key  : %s\n", priv.GetBase16().c_str());
+        printf("mini : %s\n", mini.c_str());
+        keys = fopen(fileResultPartial.c_str(), "a+");
+        fprintf(keys, "%s\n", address);
+        fprintf(keys, "%s\n", mini.c_str());
+        fprintf(keys, "%s\n\n", priv.GetBase16().c_str());
+        fclose(keys);
+    }
+}
+
+bool incrementBase58(std::string& s) {
+    static const std::string alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    for (int i = s.size() - 1; i >= 0; --i) {
+        size_t pos = alphabet.find(s[i]);
+        if (pos == std::string::npos) return false;
+        pos++;
+        if (pos < alphabet.size()) {
+            s[i] = alphabet[pos];
+            return true;
+        }
+        s[i] = alphabet[0];
+    }
+    return false;
+}
+
+void toDigits(const std::string& s, uint8_t digits[22]) {
+    static const std::string alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    for (int i = 0; i < 22; ++i) {
+        digits[i] = alphabet.find(s[i]);
+    }
+}
+
+uint64_t distanceBase58(const uint8_t* start, const uint8_t* end) {
+    uint64_t s = 0, e = 0;
+    for (int i = 0; i < 22; ++i) {
+        s = s * 58 + start[i];
+        e = e * 58 + end[i];
+    }
+    return e - s;
+}
+
+void addBase58Host(uint8_t* digits, uint64_t add) {
+    for (int i = 21; i >= 0 && add; --i) {
+        uint64_t sum = digits[i] + (add % 58);
+        digits[i] = sum % 58;
+        add = add / 58 + sum / 58;
+    }
+}
+
+std::string offsetToMini(const uint8_t* startDigits, uint64_t offset) {
+    static const std::string alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    uint8_t digits[22];
+    memcpy(digits, startDigits, 22);
+    addBase58Host(digits, offset);
+    std::string s(22, '1');
+    for (int i = 0; i < 22; ++i) {
+        s[i] = alphabet[digits[i]];
+    }
+    return s;
+}
+
+void bruteForceMinikey(const std::string& start, const std::string& end) {
+    uint8_t startDigits[22], endDigits[22];
+    toDigits(start, startDigits);
+    toDigits(end, endDigits);
+    uint64_t total = distanceBase58(startDigits, endDigits) + 1;
+    uint64_t capacity = (uint64_t)BLOCK_NUMBER * BLOCK_THREADS * THREAD_STEPS;
+    MiniResult* results;
+    uint32_t* count;
+    bool* flag;
+    cudaMallocManaged(&results, sizeof(MiniResult) * BLOCK_NUMBER * BLOCK_THREADS);
+    cudaMallocManaged(&count, sizeof(uint32_t));
+    cudaMallocManaged(&flag, sizeof(bool));
+    uint8_t* d_start;
+    cudaMalloc(&d_start, 22);
+    uint64_t processed = 0;
+    while (processed < total && !RESULT) {
+        uint64_t batch = min(capacity, total - processed);
+        cudaMemcpy(d_start, startDigits, 22, cudaMemcpyHostToDevice);
+        *count = 0; *flag = false;
+        kernelMinikey<<<BLOCK_NUMBER, BLOCK_THREADS>>>(d_start, results, count, flag, batch, THREAD_STEPS);
+        cudaDeviceSynchronize();
+        for (uint32_t i = 0; i < *count; ++i) {
+            std::string mini = offsetToMini(startDigits, results[i].index);
+            Int priv; priv.Set32Bytes(results[i].priv);
+            processMinikeyCandidate(priv, mini);
+            if (RESULT) break;
+        }
+        addBase58Host(startDigits, batch);
+        processed += batch;
+    }
+    cudaFree(d_start);
+    cudaFree(results);
+    cudaFree(count);
+    cudaFree(flag);
+}
+
 void printConfig() {
     printf("Range start: %s\n", RANGE_START_TOTAL.GetBase16().c_str());
     printf("Range end  : %s\n", RANGE_END.GetBase16().c_str());
@@ -894,6 +1050,7 @@ void showHelp()  {
     printf("    -stride hexKeyStride -rangeStart hexKeyStart [-rangeEnd hexKeyEnd] [-checksum hexChecksum] \n");
     printf("    -wifStart wifKeyStart [-wifEnd wifKeyEnd]\n");
     printf("    [-decode wifToDecode] \n");
+    printf("    [-mini miniStart miniEnd] \n");
     printf("    [-restore statusFile] \n");
     printf("    [-listDevices] \n");
     printf("    [-v] \n");
@@ -944,6 +1101,14 @@ bool readArgs(int argc, char** argv) {
             WIF_TO_DECODE = string(argv[a]);
             DECODE = true;
             return false;
+        }
+        else if (strcmp(argv[a], "-mini") == 0) {
+            if (a + 2 >= argc) {
+                return true;
+            }
+            MINIKEY_MODE = true;
+            MINIKEY_START = string(argv[++a]);
+            MINIKEY_END = string(argv[++a]);
         }
         else if (strcmp(argv[a], "-listDevices") == 0) {
             showDevices = true;


### PR DESCRIPTION
## Summary
- Offload Casascius 22-character minikey search to a CUDA kernel
- Convert host minikey ranges to base58 digits and batch GPU checks
- Collect candidate private keys on GPU and verify addresses on CPU

## Testing
- `make -C WifSolverCuda` *(fails: nvcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bafc302eac832b85b6f760bf1f481f